### PR TITLE
add target to source link

### DIFF
--- a/templates/partials/page.html.hbs
+++ b/templates/partials/page.html.hbs
@@ -27,6 +27,6 @@
   <body>
     <div id="title"><h1>{{> title}}</h1></div>
     {{~> page}}
-    <div id="footer">This site is running <a href="{{config.urls.sources}}">ff-node-monitor</a>, which is free and open source software.</div>
+    <div id="footer">This site is running <a href="{{config.urls.sources}}" target="_blank">ff-node-monitor</a>, which is free and open source software.</div>
   </body>
 </html>


### PR DESCRIPTION
If the target is missing and the node-monitor is loaded inside an iframe with https, there will be an error, that an external URL is not allowed in the iframe