### PR TITLE
RFC: revert removal of support for manual node ID

### DIFF
--- a/templates/list.html.hbs
+++ b/templates/list.html.hbs
@@ -46,13 +46,28 @@
 
   <h3>Knoten hinzufügen</h3>
   <div class="formgrid">
+    <div class="fieldgrid">
+      <div>Knoten-ID manuell eingeben:</div>
+      <input type="text" name="node" form="manual-form" id="manual-node" style="width:100%;">
+    </div>
+    <div class="button">
+      <form method="post" action="prepare_action" id="manual-form">
+        <input type="hidden" name="email" value="{{form.email}}">
+        <input type="hidden" name="op" value="add">
+        <input type="submit" id="manual-form-submit" value="Hinzufügen">
+      </form>
+    </div>
+    <div style="grid-column: span 2; padding-top: 1.5em;"></div>
     <div>
-      <select name="node" id="list-node" form="list-form" style="width:100%;" data-placeholder="Knoten auswählen...">
-        <option disabled selected></option>
-        {{#each all_nodes}}
-          <option value="{{this.id}}">{{this.name}} ({{this.id}})</option>
-        {{/each}}
-      </select>
+      <div>Knotennamen aus Liste auswählen:</div>
+      <div>
+        <select name="node" id="list-node" form="list-form" style="width:100%;" data-placeholder="Knoten auswählen...">
+          <option disabled selected></option>
+          {{#each all_nodes}}
+            <option value="{{this.id}}">{{this.name}} ({{this.id}})</option>
+          {{/each}}
+        </select>
+      </div>
     </div>
     <div class="button" style="align-self: end">
       <form method="post" action="prepare_action" id="list-form">
@@ -71,7 +86,8 @@
     function is_good_str(s) {
       return s != null && s != "";
     }
-    function upd_submit_button() {
+    function upd_submit_buttons() {
+      $('#manual-form-submit').prop('disabled', !is_good_str($("#manual-node").val()));
       $('#list-form-submit').prop('disabled', !is_good_str($("#list-node").val()));
     }
 
@@ -80,8 +96,9 @@
         search_contains: true,
         allow_single_deselect: true,
         no_results_text: "Kein Knoten gefunden für",
-      }).change(upd_submit_button);
-      upd_submit_button();
+      }).change(upd_submit_buttons);
+      $("#manual-node").on('input', upd_submit_buttons);
+      upd_submit_buttons();
       console.log("init done");
     });
   </script>


### PR DESCRIPTION
 (reverted from commit 66bd85ea86571b59b324b4393ddbb34916e2c891)

untested, but we should re-enable this. Maybe we should add a config option to show the mac-address input filed or not?