### PR TITLE
better example value for min_online_nodes

### DIFF
--- a/Rocket.toml.dist
+++ b/Rocket.toml.dist
@@ -7,8 +7,8 @@ instance_article_dative = "der"
 # The sender address of the emails that are sent by ff-node-monitor.
 email_from = "...@...freifunk.net"
 # Optional: When fewer nodes than this are online in the nodes.json file, the database won't be updated
-# and there will be no warning mails sent. If set, this should be at least higher than the number of
-# gateways in the network
+# and there will be no warning mails sent. If set, this should be at least as high as number of
+# gateways in the network (to handle the case where only those are shown as online).
 #min_online_nodes = 10
 
 [global.ff-node-monitor.urls]

--- a/Rocket.toml.dist
+++ b/Rocket.toml.dist
@@ -7,8 +7,9 @@ instance_article_dative = "der"
 # The sender address of the emails that are sent by ff-node-monitor.
 email_from = "...@...freifunk.net"
 # Optional: When fewer nodes than this are online in the nodes.json file, the database won't be updated
-# and there will be no warning mails sent.
-#min_online_nodes = 1
+# and there will be no warning mails sent. If set, this should be at least higher than the number of
+# gateways in the network
+#min_online_nodes = 10
 
 [global.ff-node-monitor.urls]
 # The root URL where you will be hosting ff-node-monitor (with trailing slash)

--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -73,8 +73,9 @@ instance_article_dative = "der"
 # The sender address of the emails that are sent by ff-node-monitor.
 email_from = "$EMAIL_FROM"
 # Optional: When fewer nodes than this are online in the nodes.json file, the database won't be updated
-# and there will be no warning mails sent.
-#min_online_nodes = 1
+# and there will be no warning mails sent. If set, this should be at least higher than the number of
+# gateways in the network
+#min_online_nodes = 10
 
 [global.ff-node-monitor.urls]
 # The root URL where you will be hosting ff-node-monitor (with trailing slash)

--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -73,8 +73,8 @@ instance_article_dative = "der"
 # The sender address of the emails that are sent by ff-node-monitor.
 email_from = "$EMAIL_FROM"
 # Optional: When fewer nodes than this are online in the nodes.json file, the database won't be updated
-# and there will be no warning mails sent. If set, this should be at least higher than the number of
-# gateways in the network
+# and there will be no warning mails sent. If set, this should be at least as high as number of
+# gateways in the network (to handle the case where only those are shown as online).
 #min_online_nodes = 10
 
 [global.ff-node-monitor.urls]


### PR DESCRIPTION
usually, even if the respondd service doesn't work, there are still some few servers, that send out respondd directly via alias.json, so the minimum should be higher than the number of gateways in the network